### PR TITLE
Add rpm package (for rpmbuild)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ LABEL "com.github.actions.icon"="package"
 LABEL "com.github.actions.color"="green"
 
 RUN apk --no-cache add build-base
+RUN apk --no-cache add rpm
 RUN apk --no-cache add tar
 RUN apk --no-cache add zip
 RUN gem install --no-document fpm -v 1.11.0


### PR DESCRIPTION
I was trying to use your Github Action to build both deb and rpm packages. The first seems to work fine, but for the latter I got an error because `rpmbuild` was not available. It's part of the `rpm` package for Alpine. Could it be added?