### PR TITLE
update ruby base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2-alpine
+FROM ruby:3-alpine
 LABEL "maintainer"="bpicode"
 
 LABEL "com.github.actions.name"="github-action-fpm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk --no-cache add build-base
 RUN apk --no-cache add rpm
 RUN apk --no-cache add tar
 RUN apk --no-cache add zip
-RUN gem install --no-document fpm -v 1.11.0
+RUN gem install --no-document fpm -v 1.15.1
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
dotenv requires Ruby version >= 3.0
current pulled version is 2.7.8.225